### PR TITLE
Fix format to work with Gitlab

### DIFF
--- a/flake8_formatter_junit_xml/formatter.py
+++ b/flake8_formatter_junit_xml/formatter.py
@@ -49,7 +49,11 @@ class JUnitXmlFormatter(base.BaseFormatter):
         name = '{0}, {1}'.format(error.code, error.text)
         test_case = TestCase(
             name,
-            classname=error.filename,
+            classname="%(path)s:%(row)d:%(col)d" % {
+                "path": error.filename,
+                "row": error.line_number,
+                "col": error.column_number,
+            },
             file=error.filename,
             line=error.line_number
         )
@@ -68,7 +72,7 @@ class JUnitXmlFormatter(base.BaseFormatter):
     # Add a dummy test if no error found
     def finished(self, filename):
         if len(self.test_suites[filename].test_cases) == 0:
-            dummy_case = TestCase("Check passed", classname=filename, file=filename)
+            dummy_case = TestCase("Check passed", file=filename)
             self.test_suites[filename].test_cases.append(dummy_case)
 
     # sort to generate a stable output

--- a/flake8_formatter_junit_xml/formatter.py
+++ b/flake8_formatter_junit_xml/formatter.py
@@ -49,7 +49,7 @@ class JUnitXmlFormatter(base.BaseFormatter):
         name = '{0}, {1}'.format(error.code, error.text)
         test_case = TestCase(
             name,
-            # classname=error.filename,
+            classname=error.filename,
             file=error.filename,
             line=error.line_number
         )
@@ -68,7 +68,7 @@ class JUnitXmlFormatter(base.BaseFormatter):
     # Add a dummy test if no error found
     def finished(self, filename):
         if len(self.test_suites[filename].test_cases) == 0:
-            dummy_case = TestCase("Check passed", file=filename)
+            dummy_case = TestCase("Check passed", classname=filename, file=filename)
             self.test_suites[filename].test_cases.append(dummy_case)
 
     # sort to generate a stable output

--- a/flake8_formatter_junit_xml/formatter.py
+++ b/flake8_formatter_junit_xml/formatter.py
@@ -20,7 +20,12 @@ class JUnitXmlFormatter(base.BaseFormatter):
     # Do not write each error
     def handle(self, error):
         name = '{0}, {1}'.format(error.code, error.text)
-        test_case = TestCase(name, file=error.filename, line=error.line_number)
+        test_case = TestCase(
+            name,
+            classname=error.filename,
+            file=error.filename,
+            line=error.line_number
+        )
         test_case.add_failure_info(message=self.format(error), output=self.show_source(error))
         self.test_suites[error.filename].test_cases.append(test_case)
 
@@ -36,7 +41,7 @@ class JUnitXmlFormatter(base.BaseFormatter):
     # Add a dummy test if no error found
     def finished(self, filename):
         if len(self.test_suites[filename].test_cases) == 0:
-            dummy_case = TestCase("Check passed", file=filename)
+            dummy_case = TestCase("Check passed", classname=filename, file=filename)
             self.test_suites[filename].test_cases.append(dummy_case)
 
     # sort to generate a stable output

--- a/flake8_formatter_junit_xml/formatter.py
+++ b/flake8_formatter_junit_xml/formatter.py
@@ -5,6 +5,33 @@ from junit_xml import TestSuite, TestCase
 class JUnitXmlFormatter(base.BaseFormatter):
     """JUnit XML formatter for Flake8."""
 
+    # Override show_statistics to always print to stdout instead of to the file
+    def show_statistics(self, statistics):
+        for error_code in statistics.error_codes():
+            stats_for_error_code = statistics.statistics_for(error_code)
+            statistic = next(stats_for_error_code)
+            count = statistic.count
+            count += sum(stat.count for stat in stats_for_error_code)
+            print(
+                "{count:<5} {error_code} {message}".format(
+                    count=count,
+                    error_code=error_code,
+                    message=statistic.message,
+                ),
+                end=self.newline
+            )
+
+    # Override show_benchmarks to always print to stdout instead of to the file.
+    def show_benchmarks(self, benchmarks):
+        float_format = "{value:<10.3} {statistic}".format
+        int_format = "{value:<10} {statistic}".format
+        for statistic, value in benchmarks:
+            if isinstance(value, int):
+                benchmark = int_format(statistic=statistic, value=value)
+            else:
+                benchmark = float_format(statistic=statistic, value=value)
+            print(benchmark, end=self.newline)
+
     def after_init(self):
         self.test_suites = {}
 
@@ -22,7 +49,7 @@ class JUnitXmlFormatter(base.BaseFormatter):
         name = '{0}, {1}'.format(error.code, error.text)
         test_case = TestCase(
             name,
-            classname=error.filename,
+            # classname=error.filename,
             file=error.filename,
             line=error.line_number
         )
@@ -41,7 +68,7 @@ class JUnitXmlFormatter(base.BaseFormatter):
     # Add a dummy test if no error found
     def finished(self, filename):
         if len(self.test_suites[filename].test_cases) == 0:
-            dummy_case = TestCase("Check passed", classname=filename, file=filename)
+            dummy_case = TestCase("Check passed", file=filename)
             self.test_suites[filename].test_cases.append(dummy_case)
 
     # sort to generate a stable output


### PR DESCRIPTION
Updated stats and benchmark output to always go to stdout to prevent them from breaking the xml format.

Added classname to the output of the JUnit xml.